### PR TITLE
修复桌面版 comfyui 媒体浏览器列表404

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -81,6 +81,9 @@ _load_nodes_from_module(".aiia_utils_nodes", "aiia_utils_nodes")
 # 5. 处理 aiia_video_nodes.py (新增部分)
 _load_nodes_from_module(".aiia_video_nodes", "aiia_video_nodes")
 
+# 6. 处理 aiia_browser_node.py (新增 - 确保HTTP路由被注册)
+_load_nodes_from_module(".aiia_browser_node", "aiia_browser_node")
+
 # 告诉 ComfyUI 这个节点包有一个包含网页资源的 'js' 目录
 WEB_DIRECTORY = "js"
 

--- a/aiia_browser_node.py
+++ b/aiia_browser_node.py
@@ -13,22 +13,14 @@ import traceback
 from io import BytesIO
 import re
 import tempfile
+import folder_paths
 
 print("--- [AIIA] Loading Media Browser API Endpoints (V19 - Robustness Fixes) ---")
 
 # --- START OF FIX: Path and Cache Logic Refinement ---
 try:
     # Attempt to find the ComfyUI root directory robustly
-    comfyui_root_path = Path(__file__).resolve().parents[2]
-    if not (comfyui_root_path / "main.py").exists():
-         current_dir = Path(__file__).resolve().parent
-         while not (current_dir / "main.py").exists() and current_dir != current_dir.parent:
-             current_dir = current_dir.parent
-         if (current_dir / "main.py").exists():
-             comfyui_root_path = current_dir
-         else:
-             raise FileNotFoundError("Could not find ComfyUI root directory.")
-    output_dir = comfyui_root_path / "output"
+    output_dir = Path(folder_paths.get_output_directory())
     print(f"--- [AIIA] Successfully located ComfyUI root. Output directory set to: {output_dir}")
 
 except Exception as e:


### PR DESCRIPTION
桌面版 ComfyUI 打开 媒体浏览器 404

* 桌面版 ComfyUI 根目录没有 main.py 文件，故无法找到，ComfyUI 的源码和 models 等目录不在同一位置
* 其他自定义设置输出目录的情况下，output 目录可能也不和models相同
* 使用官方的获取方式更加保险，也不需要尝试查找目录
* https://github.com/comfyanonymous/ComfyUI/blob/master/folder_paths.py#L114

在 macOS 桌面最新版下 0.4.51 已验证通过